### PR TITLE
small change to doctr deploy API in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
 
 script:
   - mkdocs build --clean --verbose
-  - doctr deploy --built-docs=_site --gh-pages-docs .
+  - doctr deploy --built-docs=_site .


### PR DESCRIPTION
``-gh-pages-docs`` flag is deprecated and deploy directory is now a required argument